### PR TITLE
cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ matrix:
       env:
         - TOXENV=docs
     - env:
-        - TOXENV=py27,codecov
-      python: '2.7'
-    - env:
         - TOXENV=py35,codecov
       python: '3.5'
     - env:
@@ -28,13 +25,6 @@ matrix:
     - env:
         - TOXENV=py38,codecov
       python: '3.8'
-    - env:
-        - TOXENV=pypy,codecov
-      python: 'pypy'
-    - env:
-        - TOXENV=pypy3,codecov
-        - TOXPYTHON=pypy3
-      python: 'pypy3'
 before_install:
   - python --version
   - uname -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ env:
     - SEGFAULT_SIGNALS=all
 matrix:
   include:
-    - python: '3.6'
-      env:
-        - TOXENV=check
-    - python: '3.6'
-      env:
-        - TOXENV=docs
+#    - python: '3.6'
+#      env:
+#        - TOXENV=check
+#    - python: '3.6'
+#      env:
+#        - TOXENV=docs
     - env:
         - TOXENV=py35,codecov
       python: '3.5'

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,5 +15,6 @@ include LICENSE
 include README.rst
 
 include tox.ini .travis.yml .appveyor.yml
+include *.yml
 
 global-exclude *.py[cod] __pycache__/* *.so *.dylib

--- a/README.rst
+++ b/README.rst
@@ -15,25 +15,25 @@ Overview
     * - package
       - | |version| |wheel| |supported-versions| |supported-implementations|
         | |commits-since|
-.. |docs| image:: https://readthedocs.org/projects/erpbrail.edoc.gen/badge/?style=flat
-    :target: https://readthedocs.org/projects/erpbrailedocgen
+.. |docs| image:: https://readthedocs.org/projects/erpbrasil.edoc.gen/badge/?style=flat
+    :target: https://readthedocs.org/projects/erpbrasiledocgen
     :alt: Documentation Status
 
-.. |travis| image:: https://api.travis-ci.org/mileo/erpbrail.edoc.gen.svg?branch=master
+.. |travis| image:: https://api.travis-ci.org/erpbrasil/erpbrasil.edoc.gen.svg?branch=master
     :alt: Travis-CI Build Status
-    :target: https://travis-ci.org/mileo/erpbrail.edoc.gen
+    :target: https://travis-ci.org/erpbrasil/erpbrasil.edoc.gen
 
-.. |appveyor| image:: https://ci.appveyor.com/api/projects/status/github/mileo/erpbrail.edoc.gen?branch=master&svg=true
+.. |appveyor| image:: https://ci.appveyor.com/api/projects/status/github/erpbrasil/erpbrasil.edoc.gen?branch=master&svg=true
     :alt: AppVeyor Build Status
-    :target: https://ci.appveyor.com/project/mileo/erpbrail.edoc.gen
+    :target: https://ci.appveyor.com/project/erpbrasil/erpbrasil.edoc.gen
 
-.. |requires| image:: https://requires.io/github/mileo/erpbrail.edoc.gen/requirements.svg?branch=master
+.. |requires| image:: https://requires.io/github/erpbrasil/erpbrasil.edoc.gen/requirements.svg?branch=master
     :alt: Requirements Status
-    :target: https://requires.io/github/mileo/erpbrail.edoc.gen/requirements/?branch=master
+    :target: https://requires.io/github/erpbrasil/erpbrasil.edoc.gen/requirements/?branch=master
 
-.. |codecov| image:: https://codecov.io/github/mileo/erpbrail.edoc.gen/coverage.svg?branch=master
+.. |codecov| image:: https://codecov.io/github/erpbrasil/erpbrasil.edoc.gen/coverage.svg?branch=master
     :alt: Coverage Status
-    :target: https://codecov.io/github/mileo/erpbrail.edoc.gen
+    :target: https://codecov.io/github/erpbrasil/erpbrasil.edoc.gen
 
 .. |version| image:: https://img.shields.io/pypi/v/erpbrasil.edoc.gen.svg
     :alt: PyPI Package latest release
@@ -51,9 +51,9 @@ Overview
     :alt: Supported implementations
     :target: https://pypi.org/project/erpbrasil.edoc.gen
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/mileo/erpbrail.edoc.gen/v0.1.0.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/erpbrasil/erpbrasil.edoc.gen/v0.1.0.svg
     :alt: Commits since latest release
-    :target: https://github.com/mileo/erpbrail.edoc.gen/compare/v0.1.0...master
+    :target: https://github.com/erpbrasil/erpbrasil.edoc.gen/compare/v0.1.0...master
 
 
 
@@ -72,14 +72,14 @@ Installation
 
 You can also install the in-development version with::
 
-    pip install https://github.com/mileo/erpbrail.edoc.gen/archive/master.zip
+    pip install https://github.com/erpbrasil/erpbrasil.edoc.gen/archive/master.zip
 
 
 Documentation
 =============
 
 
-https://erpbrailedocgen.readthedocs.io/
+https://erpbrasiledocgen.readthedocs.io/
 
 
 Development

--- a/README.rst
+++ b/README.rst
@@ -7,17 +7,12 @@ Overview
 .. list-table::
     :stub-columns: 1
 
-    * - docs
-      - |docs|
     * - tests
       - | |travis| |appveyor| |requires|
         | |codecov|
     * - package
       - | |version| |wheel| |supported-versions| |supported-implementations|
         | |commits-since|
-.. |docs| image:: https://readthedocs.org/projects/erpbrasil.edoc.gen/badge/?style=flat
-    :target: https://readthedocs.org/projects/erpbrasiledocgen
-    :alt: Documentation Status
 
 .. |travis| image:: https://api.travis-ci.org/erpbrasil/erpbrasil.edoc.gen.svg?branch=master
     :alt: Travis-CI Build Status
@@ -59,9 +54,69 @@ Overview
 
 .. end-badges
 
-Generate Brazil Edoc with GenerateDS
+
+Overview
+========
+
+This is a helper script for generating Python and Odoo ERP libraries for the Brazilian electronic fiscal documents using http://www.davekuhlman.org/generateDS.html. It supports all fiscal documents that have XSD schemas, that is: NF-e, CC-e, NFS-e, MDF-e, CT-e, EFD-Reinf, e-Social, GNRE, BP-e...
+
+But why a helper instead of launching generateDS manually?
+
+*  For all these fiscal documents there is a common pattern: the schemas are inside a zip archive that can be downloaded from an official URL.
+*  After normalizing the xsd file names, we launch the generateDS.py generator on them. But we also want to keep our libraries small, so edoc-gen enables to specify that only some xsd files should support both export and import.
+*  Finally automating all the steps with the proper settings allowed Raphaël (`AKRETION <https://akretion.com/pt-BR>`__) to quickly re-generate the Python libraries for all the fiscal documents and run the pytests import/export tests on them to ensure any patch in generateDS would would retain real life compatibility (He got some 6 patches merged into generateDS). And mostly it allowed him to the do the same with the Odoo mixin generator plugin: quicky re-generate all Odoo modules and ensure they install and pass the tests. The libraries and Odoo modules are typically distributed as separated packages inside different repos that can get their own bug reports, forks and contributions but it also work to generate everything in the same directory for a quick extensive testing. Automating all these steps allowed Raphaël to prove to the other Odoo OCA Brazilian localization leaders that we could finally abandon hand written XML fiscal libs such as Pysped who were a hassle to maintain for every fiscal schema and its updates.
+
+This tool was first implemented in Bash by Raphaël Valyi (`AKRETION <https://akretion.com/pt-BR>`__) in 2019 https://github.com/akretion/edoc-gen and then transcoded to Python by (`KMEE <http://www.kmee.com.br/>`__) one year later for an easier portability. It was then cleaned up again by Raphaël to work with the standard generateDS package.
+
+Usage
+=====
+
+.. code-block:: html
+
+        erpbrasil.edoc.gen.download_schema --help
+        Usage: download_schema.py [OPTIONS]
+
+          Download a list of schemas of the same service, extract it in order and
+          overwrite the files.
+
+          NFE: Has one big file with all the xsd and some small files with     new
+          fixes named "Pacote de Liberação"
+
+        Options:
+          -n, --service_name TEXT  Service Name
+          -v, --version TEXT       Version Name
+          -u, --url TEXT           List of URLs
+          -t DIRECTORY             Directory where the files will be extract
+          --help                   Show this message and exit.
+
+
+        erpbrasil.edoc.gen.generate_python --help
+        Usage: generate_python.py [OPTIONS]
+
+          Create a module in the path dest_dir and generates the python lib for each
+          xsd found in the path schema_dir
+
+          :param service_name: for example nfe :param version: v4.00 :param
+          schema_dir: /tmp/schemas :param force: flag :param dest_dir:
+          /tmp/generated_specs :return:
+
+        Options:
+          -n, --service_name TEXT   Service Name
+          -v, --version TEXT        Version Name
+          -s, --schema_dir TEXT     Schema dir
+          -f, --force               force
+          -d, --dest_dir DIRECTORY  Directory where the files will be extract
+          -i, --file_filter TEXT    File Filter
+          --help                    Show this message and exit.
 
 * Free software: MIT license
+
+
+Example for the Brazilian NFe
+=============================
+
+https://github.com/erpbrasil/nfelib
+
 
 Installation
 ============
@@ -75,11 +130,14 @@ You can also install the in-development version with::
     pip install https://github.com/erpbrasil/erpbrasil.edoc.gen/archive/master.zip
 
 
-Documentation
-=============
+Credits
+=======
 
+Authors / Maintainers:
 
-https://erpbrasiledocgen.readthedocs.io/
+- Raphaël Valyi (`AKRETION <https://akretion.com/pt-BR>`__)
+- Luis Felipe Miléo (`KMEE <http://www.kmee.com.br/>`__)
+- Gabriel Cardoso de Faria (`KMEE <http://www.kmee.com.br/>`__)
 
 
 Development

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
     keywords=[
         # eg: 'keyword1', 'keyword2', 'keyword3',
     ],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+    python_requires='>=3.5',
     install_requires=[
         'click',
         'click-log',

--- a/src/erpbrasil/edoc/gen/generate_odoo.py
+++ b/src/erpbrasil/edoc/gen/generate_odoo.py
@@ -4,8 +4,8 @@ from pathlib import Path
 import click
 import os
 import sys
-from odoo import gends_run_gen_odoo
-import generateDS
+#from odoo import gends_run_gen_odoo
+#import generateDS
 
 
 def prepare(service_name, version, dest_dir, force):
@@ -17,13 +17,9 @@ def prepare(service_name, version, dest_dir, force):
       |-__init__.py
       |-spec_models.py
       |-<version>
-    |-security
-      |-<version>
-        |-ir.model.access.csv
     """
-    dest_dir_path = os.path.join(dest_dir, 'l10n_br_spec_%s/' % service_name)
+    dest_dir_path = os.path.join(dest_dir, 'l10n_br_%s_spec/' % service_name)
     output_path = dest_dir_path + 'models/' + version
-    security_path = dest_dir_path + 'security/%s' % version
 
     if force and os.path.isdir(dest_dir_path):
         shutil.rmtree(dest_dir_path)
@@ -50,11 +46,10 @@ def prepare(service_name, version, dest_dir, force):
     'category': 'Accounting',
     'summary': '%s spec',
     'depends': ['base'],
-    'data': ['security/%s/ir.model.access.csv'],
     'installable': True,
     'application': False,
 }
-""" % (service_name, service_name, version))
+""" % (service_name, service_name))
     manifest_file.close()
 
     spec_models_file = open(dest_dir_path + 'models/spec_models.py', 'w+')
@@ -81,13 +76,6 @@ class NfeSpecMixin(models.AbstractModel):
             item.currency_id = self.env.ref('base.BRL').id
 """)
     spec_models_file.close()
-
-    os.makedirs(security_path, exist_ok=True)
-    security_dir = open(security_path + '/ir.model.access.csv', 'w+')
-    security_dir.write('id,name,model_id:id,group_id:id,'
-                       'perm_read,perm_write,perm_create,perm_unlink')
-    security_dir.close()
-
 
 def generate_file(service_name, version, output_dir, module_name, filename):
     """ Generate the odoo model for the xsd passed by filename
@@ -147,7 +135,7 @@ def generate_odoo(
     prepare(service_name, version, dest_dir, force)
 
     output_dir = os.path.join(
-        dest_dir, 'l10n_br_spec_%s/models/%s' % (service_name, version)
+        dest_dir, 'l10n_br_%s_spec/models/%s' % (service_name, version)
     )
 
     filenames = []
@@ -161,11 +149,11 @@ def generate_odoo(
             service_name, version
         )).rglob('*.xsd')]
 
-    for filename in filenames:
-        module_name = str(filename).split('/')[-1].split('_%s' % version)[0]
-        generate_file(service_name, version, output_dir, module_name, filename)
+#    for filename in filenames:
+#        module_name = str(filename).split('/')[-1].split('_%s' % version)[0]
+#        generate_file(service_name, version, output_dir, module_name, filename)
 
-    finish(output_dir)
+#    finish(output_dir)
 
 
 if __name__ == "__main__":

--- a/src/erpbrasil/edoc/gen/generate_python.py
+++ b/src/erpbrasil/edoc/gen/generate_python.py
@@ -75,20 +75,22 @@ def generate_file(
     ))
     os.makedirs(out_process_includes_dir, exist_ok=True)
 
-    subprocess.check_output([
-        'process_includes.py',
+    preprocess_args = ['process_includes.py',
         '--no-collect-includes', '-f', str(filename),
-         out_file_process_included], cwd=schema_version_dir)
+         out_file_process_included]
+    print("\n%s" % (" ".join(preprocess_args),))
+    subprocess.check_output(preprocess_args, cwd=schema_version_dir)
     out_file_generated = os.path.join(
         output_dir, "%s.py" % (module_name,))
 
-    subprocess.check_output(
-        ['generateDS.py',
+    gends_args = ['generateDS.py',
          '--no-namespace-defs',
          #'--no-collect-includes',
          '--member-specs', 'list',
          '--use-getter-setter=none', '-f', '-o',
-         out_file_generated, out_file_process_included], cwd=schema_version_dir)
+         out_file_generated, out_file_process_included]
+    print(" ".join(gends_args))
+    subprocess.check_output(gends_args, cwd=schema_version_dir)
 
     os.remove(os.path.join(schema_version_dir, out_file_process_included))
     dest_dir_path = os.path.join(dest_dir, '%slib/' % service_name)

--- a/src/erpbrasil/edoc/gen/generate_python.py
+++ b/src/erpbrasil/edoc/gen/generate_python.py
@@ -145,6 +145,12 @@ def generate_python(service_name, version, schema_dir, force, dest_dir,
             generate_file(service_name, version, output_path,
                           module_name, filename, dest_dir, schema_version_dir)
 
+    src_dir = os.path.join(dest_dir, 'src', 'nfe')
+    if os.path.isdir(src_dir):
+        for item in os.listdir(src_dir):
+            s = os.path.join(src_dir, item)
+            d = os.path.join(output_path, item)
+            shutil.copy2(s, d)
 
 if __name__ == "__main__":
     sys.exit(generate_python())

--- a/src/erpbrasil/edoc/gen/generate_python.py
+++ b/src/erpbrasil/edoc/gen/generate_python.py
@@ -63,8 +63,8 @@ def prepare(service_name, version, dest_dir, force):
             ))
 
 
-def generate_file(
-    service_name, version, output_dir, module_name, filename, dest_dir, schema_version_dir):
+def generate_file(service_name, version, output_dir, module_name, filename,
+        dest_dir, schema_version_dir):
     """ Generate the odoo model for the xsd passed by filename
     To further information see the implementation of
     gends_run_gen_odoo.generate"""
@@ -75,24 +75,17 @@ def generate_file(
     ))
     os.makedirs(out_process_includes_dir, exist_ok=True)
 
-    preprocess_args = ['process_includes.py',
-        '--no-collect-includes', '-f', str(filename),
-         out_file_process_included]
-    print("\n%s" % (" ".join(preprocess_args),))
-    subprocess.check_output(preprocess_args, cwd=schema_version_dir)
     out_file_generated = os.path.join(
         output_dir, "%s.py" % (module_name,))
 
     gends_args = ['generateDS.py',
          '--no-namespace-defs',
-         #'--no-collect-includes',
          '--member-specs', 'list',
          '--use-getter-setter=none', '-f', '-o',
-         out_file_generated, out_file_process_included]
+         out_file_generated, str(filename)]
     print(" ".join(gends_args))
     subprocess.check_output(gends_args, cwd=schema_version_dir)
 
-    os.remove(os.path.join(schema_version_dir, out_file_process_included))
     dest_dir_path = os.path.join(dest_dir, '%slib/' % service_name)
     doc_path = os.path.join(dest_dir_path, 'docs')
 
@@ -130,7 +123,8 @@ def generate_python(service_name, version, schema_dir, force, dest_dir,
     version = version.replace('.', '_')
     dest_dir_path = os.path.join(dest_dir, '%slib/' % service_name)
     output_path = os.path.join(dest_dir_path, version)
-    schema_version_dir = schema_dir + '/%s/%s' % (service_name, version.replace('.', '_'),)
+    schema_version_dir = schema_dir + '/%s/%s' % (service_name,
+            version.replace('.', '_'),)
 
     filenames = []
     if file_filter:
@@ -138,8 +132,7 @@ def generate_python(service_name, version, schema_dir, force, dest_dir,
             filenames += [file for file in Path(schema_version_dir
             ).rglob(pattern + '*.xsd')]
     else:
-        filenames = [file for file in Path(schema_version_dir
-        ).rglob('*.xsd')]
+        filenames = [f for f in Path(schema_version_dir).rglob('*.xsd')]
 
     for filename in filenames:
         module_name = str(filename).split('/')[-1].split('_v')[0]

--- a/src/erpbrasil/edoc/gen/generate_python.py
+++ b/src/erpbrasil/edoc/gen/generate_python.py
@@ -21,17 +21,13 @@ FILE_SKIP = ['^tipos.*', '^xmldsig.*']
 
 
 def prepare(service_name, version, dest_dir, force):
-    """ Create the module l10n_br_spec_<service_name> with the structure:
-    l10n_br_spec_<service_name>
-    |-__manifest__.py
+    """ Create the Python lib structure:
+    lib_<service_name>
     |-__init__.py
-    |-models
+    |-version
       |-__init__.py
-      |-spec_models.py
-      |-<version>
-    |-security
-      |-<version>
-        |-ir.model.access.csv
+      |-generated_models.py
+      |-custom_gends_overrides.py
     """
     version = version.replace('.', '_')
     dest_dir_path = os.path.join(dest_dir, '%slib/' % service_name)

--- a/src/erpbrasil/edoc/gen/generate_python.py
+++ b/src/erpbrasil/edoc/gen/generate_python.py
@@ -71,7 +71,7 @@ def generate_file(
 
     out_process_includes_dir = schema_version_dir
     out_file_process_included = str(os.path.join(
-        out_process_includes_dir, "preprocessed_" + module_name
+        out_process_includes_dir, "pre_%s.xsd" % (module_name,)
     ))
     os.makedirs(out_process_includes_dir, exist_ok=True)
 

--- a/src/erpbrasil/edoc/gen/generate_python.py
+++ b/src/erpbrasil/edoc/gen/generate_python.py
@@ -116,6 +116,7 @@ def generate_python(service_name, version, schema_dir, force, dest_dir,
     :param dest_dir: /tmp/generated_specs
     :return:
     """
+    dest_dir = os.path.abspath(dest_dir)
     os.makedirs(dest_dir, exist_ok=True)
 
     prepare(service_name, version, dest_dir, force)

--- a/src/erpbrasil/edoc/gen/generate_python.py
+++ b/src/erpbrasil/edoc/gen/generate_python.py
@@ -82,10 +82,11 @@ def generate_file(
 
     subprocess.check_output(
         ['generateDS.py',
-         '--no-namespace-defs', '--no-collect-includes',
+         '--no-namespace-defs',
+         #'--no-collect-includes',
+         '--member-specs', 'list',
          '--use-getter-setter=none', '-f', '-o',
          out_file_generated, out_file_process_included], cwd=schema_version_dir)
-
 
     os.remove(os.path.join(schema_version_dir, out_file_process_included))
     dest_dir_path = os.path.join(dest_dir, '%slib/' % service_name)
@@ -126,7 +127,7 @@ def generate_python(service_name, version, schema_dir, force, dest_dir,
     dest_dir_path = os.path.join(dest_dir, '%slib/' % service_name)
     output_path = os.path.join(dest_dir_path, version)
     schema_version_dir = schema_dir + '/%s/%s' % (service_name, version.replace('.', '_'),)
- 
+
     filenames = []
     if file_filter:
         for pattern in file_filter.strip('\'').split('|'):

--- a/src/erpbrasil/edoc/gen/generate_python.py
+++ b/src/erpbrasil/edoc/gen/generate_python.py
@@ -17,6 +17,8 @@ DOCS_MODULE_DOCUMENTATION = """.. automodule:: %s
     :show-inheritance:
 """
 
+FILE_SKIP = ['^tipos.*', '^xmldsig.*']
+
 
 def prepare(service_name, version, dest_dir, force):
     """ Create the module l10n_br_spec_<service_name> with the structure:
@@ -78,7 +80,7 @@ def generate_file(
         '--no-collect-includes', '-f', str(filename),
          out_file_process_included], cwd=schema_version_dir)
     out_file_generated = os.path.join(
-        output_dir, module_name.replace('.xsd', '.py'))
+        output_dir, "%s.py" % (module_name,))
 
     subprocess.check_output(
         ['generateDS.py',
@@ -138,9 +140,10 @@ def generate_python(service_name, version, schema_dir, force, dest_dir,
         ).rglob('*.xsd')]
 
     for filename in filenames:
-        module_name = str(filename).split('/')[-1].split('_%s' % version)[0]
-        generate_file(service_name, version, output_path,
-                      module_name, filename, dest_dir, schema_version_dir)
+        module_name = str(filename).split('/')[-1].split('_v')[0]
+        if not any(re.search(pattern, module_name) for pattern in FILE_SKIP):
+            generate_file(service_name, version, output_path,
+                          module_name, filename, dest_dir, schema_version_dir)
 
 
 if __name__ == "__main__":

--- a/src/erpbrasil/edoc/gen/generate_python.py
+++ b/src/erpbrasil/edoc/gen/generate_python.py
@@ -26,7 +26,7 @@ def prepare(service_name, version, dest_dir, force):
     |-__init__.py
     |-version
       |-__init__.py
-      |-generated_models.py
+      |-generated_bindings.py
       |-custom_gends_overrides.py
     """
     version = version.replace('.', '_')
@@ -76,6 +76,7 @@ def generate_file(service_name, version, output_dir, module_name, filename,
 
     gends_args = ['generateDS.py',
          '--no-namespace-defs',
+         '--no-dates',
          '--member-specs', 'list',
          '--use-getter-setter=none', '-f', '-o',
          out_file_generated, str(filename)]

--- a/src/erpbrasil/edoc/gen/generate_python.py
+++ b/src/erpbrasil/edoc/gen/generate_python.py
@@ -138,7 +138,7 @@ def generate_python(service_name, version, schema_dir, force, dest_dir,
             generate_file(service_name, version, output_path,
                           module_name, filename, dest_dir, schema_version_dir)
 
-    src_dir = os.path.join(dest_dir, 'src', 'nfe')
+    src_dir = os.path.join(dest_dir, 'src', service_name)
     if os.path.isdir(src_dir):
         for item in os.listdir(src_dir):
             s = os.path.join(src_dir, item)

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ deps =
     jinja2
     matrix
     tox
+    click
 skip_install = true
 commands =
     python ci/bootstrap.py --no-env
@@ -15,7 +16,7 @@ envlist =
     clean,
     check,
     docs,
-    {py27,py35,py36,py37,py38,pypy,pypy3},
+    {py35,py36,py37,py38,pypy,pypy3},
     report
 ignore_basepython_conflict = true
 
@@ -23,7 +24,6 @@ ignore_basepython_conflict = true
 basepython =
     pypy: {env:TOXPYTHON:pypy}
     pypy3: {env:TOXPYTHON:pypy3}
-    py27: {env:TOXPYTHON:python2.7}
     py35: {env:TOXPYTHON:python3.5}
     {py36,docs}: {env:TOXPYTHON:python3.6}
     py37: {env:TOXPYTHON:python3.7}


### PR DESCRIPTION
- [x] works with the standard generateDS package. Much better than a 2 years old fork including many different things (packaging, Odoo generator) together with no chance of being merged in the upstream. And this was also not necessary as the Odoo model generator could be extracted as a standalone package here https://github.com/akretion/generateds-odoo . Having an up to date generateDS package with the latest bugfix and documention sounds much better.
- [x] brings back the initial Akretion bash features of copying the src files and filtering out unwanted files streamline the generation process (see commits).
- [x] get the basic tests (Travis+Tox) passing again. Python 2.7 was not working anyway and was removed.
- [x] disabled the Odoo mixins generation for now as this is not the bottleneck in OCA/l10n-brazil (clean up of the fiscal low level libs is!) and as for the l10n_br_nfe_spec it involves only 1 xsd file and the command can be executed manually from the generateds-odoo generator for now.
- [x] has a basic README were the origin of the work is made clear.
- [x] simplifies and fix the code generation (see commits)