### PR TITLE
unzip even zith .ZIP creative extension

### DIFF
--- a/src/erpbrasil/edoc/gen/download_schema.py
+++ b/src/erpbrasil/edoc/gen/download_schema.py
@@ -48,7 +48,7 @@ def download_schema(service_name, version, url, tmp_dir):
             )
             filename = params["filename"]
 
-        file_path = os.path.join(tmp_dir, filename)
+        file_path = os.path.join(tmp_dir, filename.replace('.ZIP', '.zip'))
         click.echo("Downloading file to: {}".format(file_path))
         urlretrieve(u, file_path)
         #


### PR DESCRIPTION
Bom já teve o cara que achou bom usar o encoding iso-8859-1 para o evento de manifestação do destinatário, agora tem mais um gênio concursado da Fazenda que decidiu fazer algo criativo na vida dele chamando o pacote de consulta de cadastro com extenção ".ZIP".
Porque não neh?

Ai com esse fix https://github.com/akretion/nfelib funciona com o pacote de Consulta Cadastro.
E senao explode assim:

```
  File "/usr/local/lib/python3.8/dist-packages/erpbrasil.edoc.gen-0.1.0-py3.8.egg/erpbrasil/edoc/gen/download_schema.py", line 58, in download_schema
    shutil.unpack_archive(file_path, extract_dir)
  File "/usr/lib/python3.8/shutil.py", line 1223, in unpack_archive
    raise ReadError("Unknown archive format '{0}'".format(filename))
shutil.ReadError: Unknown archive format '/tmp/generated/PL_006t.ZIP'
```